### PR TITLE
another batch of fixes

### DIFF
--- a/annotations/inputs/vep/anton_annotations_deepvariant.json
+++ b/annotations/inputs/vep/anton_annotations_deepvariant.json
@@ -1,7 +1,6 @@
 {
   "vep_annotations.destination": "/data/gwas/anton/vep/deepvariant",
   "vep_annotations.vcf": "/data/gwas/anton/variants/strelka_run/results/variants/variants.vcf",
-  "vep_annotations.vcf_tbi": "/data/gwas/anton/variants/strelka_run/results/variants/variants.vcf.tbi",
   "vep_annotations.name": "antonkulaga",
   "vep_annotations.ensembl_cache": "/data/ensembl/102/cache",
   "vep_annotations.ensembl_plugins": "/data/ensembl/102/plugins",
@@ -9,9 +8,11 @@
   "vep_annotations.reference": "/data/gwas/homo_sapiens_ensembl_102/Homo_sapiens.GRCh38.dna.primary_assembly.fa",
   "vep_annotations.G2P": "/data/gwas/annotations/gene2phenotype/DDG2P.csv",
   "vep_annotations.disease_associations": "/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz",
-  "vep_annotations.disease_associations_tbi": "/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi",
   "vep_annotations.clinvar": "/data/gwas/annotations/clinvar.vcf.gz",
   "vep_annotations.clinvar_tbi": "/data/gwas/annotations/clinvar.vcf.gz.tbi",
   "vep_annotations.condel": false,
-  "vep_annotations.conservation": false
+  "vep_annotations.conservation": false,
+  "vep_annotations.database": false,
+  "vep_annotations.db_host": "useastdb.ensembl.org",
+  "vep_annotations.threads": 7
 }

--- a/annotations/inputs/vep/anton_annotations_strelka.json
+++ b/annotations/inputs/vep/anton_annotations_strelka.json
@@ -13,5 +13,6 @@
   "vep_annotations.clinvar": "/data/gwas/annotations/clinvar.vcf.gz",
   "vep_annotations.clinvar_tbi": "/data/gwas/annotations/clinvar.vcf.gz.tbi",
   "vep_annotations.condel": false,
-  "vep_annotations.conservation": false
+  "vep_annotations.database": false,
+  "vep_annotations.threads": 12
 }

--- a/annotations/vep_annotations.wdl
+++ b/annotations/vep_annotations.wdl
@@ -3,10 +3,10 @@ version development
 workflow vep_annotations{
     input{
         File vcf
-        File? vcf_tbi
         String name
         String species = "homo_sapiens"
-        Int threads = 16
+        String db_host
+        Int threads
         File reference
         #Boolean offline = true
         Boolean database = false
@@ -17,7 +17,6 @@ workflow vep_annotations{
         Int buffer_size = 5000
         File G2P
         File disease_associations
-        File? disease_associations_tbi
         File clinvar
         File? clinvar_tbi
         Boolean condel = false
@@ -29,10 +28,13 @@ workflow vep_annotations{
                 ensembl_cache = ensembl_cache,
                 name = name+"_variant_annotations.tsv",
                 ensembl_plugins = ensembl_plugins,
+                db_host = db_host,
+                species = species,
+                threads = threads,
+                database = database,
                 fasta = reference,
                 species = species,
                 disease_associations = disease_associations,
-                disease_associations_tbi = disease_associations_tbi,
                 G2P = G2P,
                 check_sorted = check_sorted,
                 buffer_size = buffer_size,
@@ -53,14 +55,15 @@ workflow vep_annotations{
         }
 }
 
+
 task vep {
     input {
         File vcf
-        File? vcf_tbi
-        String name = "variant_effect_output.tsv"
-        String species = "homo_sapiens"
-        Int threads = 8
-        Boolean database = false
+        String name #= "variant_effect_output.tsv"
+        String species
+        String db_host 
+        Int threads
+        Boolean database
         File fasta
         #Boolean offline = true
         File ensembl_cache
@@ -69,7 +72,6 @@ task vep {
         Int buffer_size = 5000
         File G2P
         File disease_associations
-        File? disease_associations_tbi
         File clinvar
         File? clinvar_tbi
         Boolean conservation
@@ -80,13 +82,24 @@ task vep {
 
     command {
         set -e
-        ln -s ~{vcf} .
-        ~{"ln -s "+ vcf_tbi  +" ."}
+        if (file ~{vcf} | grep -q "gzip" ) ; then #https://github.com/Ensembl/ensembl-vep/issues/739
+          gunzip -c ~{vcf} > ./input.vcf 
+        else
+          ln -s ~{vcf} ./input.vcf         
+        fi
+        bgzip -c ./input.vcf > ~{"./"+basename(vcf, ".gz")+".gz"}
         ~{"ln -s "+ clinvar  +" ."}
         ~{"ln -s "+ clinvar_tbi  +" ."}
-        ~{"ln -s "+ disease_associations  +" ."}
-        ~{"ln -s "+ disease_associations_tbi  +" ."}
-        vep --verbose --input_file ~{basename(vcf)} -o ~{name} --tab --species ~{species} --fork ~{threads} --everything --fasta ~{fasta} \
+        ~{"ln -s "+ disease_associations  +" ."} 
+        # https://github.com/Ensembl/VEP_plugins/blob/release/102/DisGeNET.pm
+        tabix -p vcf ~{"./"+basename(vcf, ".gz")+".gz"}
+        tabix -s 2 -b 3 -e 3 ~{basename(disease_associations)}
+        stat ~{"./"+basename(vcf, ".gz")+".gz"}
+        stat ~{"./"+basename(vcf, ".gz")+".gz.tbi"}
+        stat ~{basename(disease_associations)+".tbi"}
+               
+        vep --verbose --host ~{db_host} --input_file ~{"./"+basename(vcf, ".gz")+".gz"} -o ~{name} --tab --species ~{species} --fork ~{threads} \
+        --everything --fasta ~{fasta} \
         ~{if(database) then "--database" else  "--cache"} --dir_cache ~{ensembl_cache} --dir_plugins ~{ensembl_plugins} \
         --symbol --check_existing ~{if(check_sorted) then "" else "--no_check_variants_order"} \
         --max_sv_size 1000000000 --buffer_size ~{buffer_size}   \

--- a/config/cromwell/application.conf
+++ b/config/cromwell/application.conf
@@ -239,6 +239,7 @@ backend {
           rm -f ${docker_cid}
           # run as in the original configuration without --rm flag (will remove later)
           docker run \
+            --network=host \
             --cidfile ${docker_cid} \
             ${"--cpus=" + docker_cpu} \
             ${"--memory=" + docker_memory } \

--- a/data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz.dvc
+++ b/data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz.dvc
@@ -1,0 +1,9 @@
+md5: 8f94d4825f7c85ebbc52ce3631ea3de1
+deps:
+- etag: '"aa751c-5a5aded5debeb"'
+  path: https://www.disgenet.org/static/disgenet_ap1/files/downloads/all_variant_disease_pmid_associations.tsv.gz
+outs:
+- md5: a393c9e8e104297aadcb7188f6460eaf
+  size: 11171100
+  path: all_variant_disease_pmid_associations.tsv.gz
+  cache: false

--- a/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.dvc
+++ b/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.dvc
@@ -1,9 +1,0 @@
-md5: a3428046b58d6ffeb819f6bb969a3dda
-deps:
-- etag: '"eef02876b324e403"'
-  path: http://agingkills.eu:8001/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
-outs:
-- md5: 05ff81dc87278116b0330df99fced244
-  size: 101101733
-  path: all_variant_disease_pmid_associations_final.tsv.gz
-  cache: false

--- a/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi.dvc
+++ b/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi.dvc
@@ -1,9 +1,0 @@
-md5: 349559f6d157a8ee0112679afb07011e
-deps:
-- etag: '"7ac1e176b57cb631"'
-  path: http://agingkills.eu:8001/data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi
-outs:
-- md5: fdce855c944ba7794fc2723d46376d79
-  size: 492382
-  path: all_variant_disease_pmid_associations_final.tsv.gz.tbi
-  cache: false

--- a/data/gwas/annotations/clinvar.vcf.gz.dvc
+++ b/data/gwas/annotations/clinvar.vcf.gz.dvc
@@ -1,9 +1,9 @@
-md5: 4c9f6fb8ca533052233102162c6ff012
+md5: cacf0606c4be8fd1c609fd294ca28d9e
 deps:
-- etag: '"21194b2-5ba425ab56e6d"'
+- etag: '"211af3c-5badda73338c9"'
   path: http://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
 outs:
-- md5: 9fab121ac6a9952ab03314f2cf3f5c3f
-  size: 34706610
+- md5: 487e6796ae4be8696d51ef450d5793de
+  size: 34713404
   path: clinvar.vcf.gz
   cache: false

--- a/data/gwas/annotations/clinvar.vcf.gz.tbi.dvc
+++ b/data/gwas/annotations/clinvar.vcf.gz.tbi.dvc
@@ -1,9 +1,9 @@
-md5: 7e4e648d88cff7a2a7a589f7f4b03ffb
+md5: b783831befdec2610625c610149f882f
 deps:
-- etag: '"47a44-5ba425aba3ccb"'
+- etag: '"47ab0-5badda736c31d"'
   path: http://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz.tbi
 outs:
-- md5: 4c9982e21d729ca921297796d1adabf6
-  size: 293444
+- md5: b85b29f474a7f6899ddf1ad8b8c21140
+  size: 293552
   path: clinvar.vcf.gz.tbi
   cache: false

--- a/dna-seq-pipeline/alignment.wdl
+++ b/dna-seq-pipeline/alignment.wdl
@@ -6,11 +6,11 @@ workflow alignment {
         File reference
         String name
         String destination
-        Int align_threads = 12
-        Int sort_threads = 12
-        Int max_memory_gb = 36
-        Int coverage_sampling = 1000
-        String? gencore_quality
+        Int align_threads# = 12
+        Int sort_threads# = 12
+        Int max_memory_gb# = 36
+        Int coverage_sampling# = 1000
+        String? gencore_quality 
     }
 
     call minimap2 {
@@ -33,7 +33,7 @@ workflow alignment {
             reference = reference,
             sorted_bam = sambamba_sort.out,
             name = name,
-            quality  = gencore_quality,
+            quality = gencore_quality,
             coverage_sampling = coverage_sampling,
             max_memory = max_memory_gb
     }
@@ -118,10 +118,10 @@ task gencore {
         Int supporting_reads = 1
         Float ratio_threshold = 0.8
         String? quality #"--high_qual"
-        Int coverage_sampling = 1000
+        Int coverage_sampling# = 1000
     }
     command {
-        gencore --coverage_sampling ~{1000} --ratio_threshold=~{ratio_threshold} -s ~{supporting_reads} ~{quality} -i ~{sorted_bam} -o ~{name}.bam -r ~{reference}
+        gencore --coverage_sampling ~{coverage_sampling} --ratio_threshold=~{ratio_threshold} -s ~{supporting_reads} ~{quality} -i ~{sorted_bam} -o ~{name}.bam -r ~{reference}
         samtools index ~{name}.bam  ~{name}.bam.bai
     }
 

--- a/dna-seq-pipeline/cleanup.wdl
+++ b/dna-seq-pipeline/cleanup.wdl
@@ -4,10 +4,11 @@ workflow cleanup {
     input {
         Array[File]+ reads
         String destination
+        Int threads# = 16
         Boolean is_paired = true #now it supports only paired, TODO: fix for single
     }
 
-    call fastp { input: reads = reads, is_paired = is_paired }
+    call fastp { input: reads = reads, threads = threads, is_paired = is_paired }
     call copy as copy_cleaned { input: destination = destination, files = fastp.out }
 
 
@@ -23,12 +24,13 @@ workflow cleanup {
 task fastp {
     input {
         Array[File]+ reads
+        Int threads
         Boolean is_paired
     }
 
     command {
         fastp --cut_front --cut_tail --cut_right --overrepresentation_analysis \
-        -i ~{reads[0]} -o ~{basename(reads[0], ".fastq.gz")}_cleaned.fastq.gz \
+        -i ~{reads[0]} -w ~{threads} -o ~{basename(reads[0], ".fastq.gz")}_cleaned.fastq.gz \
         ~{if( is_paired ) then "--detect_adapter_for_pe " + "--correction -I "+reads[1]+" -O " + basename(reads[1], ".fastq.gz") +"_cleaned.fastq.gz" else ""}
     }
 

--- a/dna-seq-pipeline/deep_variant.wdl
+++ b/dna-seq-pipeline/deep_variant.wdl
@@ -20,8 +20,10 @@ workflow DeepVariant {
         input:  bam = bam, bai = bai,
             regions = regions,
             name = name,
-            reference=reference, reference_fai = reference_fai,
-            threads = threads, mode = mode
+            reference=reference, 
+            reference_fai = reference_fai,
+            threads = threads, 
+            mode = mode
     }
     call copy as copy_deepvariant {
         input: files = [go_deep.vcf, go_deep.gvcf, go_deep.report, go_deep.interim], destination = destination

--- a/dna-seq-pipeline/dna_seq_pipeline.wdl
+++ b/dna-seq-pipeline/dna_seq_pipeline.wdl
@@ -12,17 +12,20 @@ workflow dna_seq_pipeline {
         Boolean is_paired = true
         File reference #i.e. Homo_sapiens.GRCh38.dna.primary_assembly.fa
         File reference_fai #i.e. Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai
-        Int align_threads = 12
-        Int sort_threads = 12
-        Int variant_calling_threads = 16
-        Int coverage_sampling = 1000
-        Int max_memory_gb = 42
+        Int align_threads# = 12
+        Int sort_threads# = 12
+        Int variant_calling_threads# = 16
+        Int coverage_sampling# = 1000
+        Int max_memory_gb# = 42
         String name
+        String? quality 
     }
 
     call clean.cleanup as cleanup{
         input:
-            reads = reads, destination = destination + "/fastq/cleaned"
+            reads = reads,
+            threads = sort_threads, 
+            destination = destination + "/fastq/cleaned"
     }
 
 
@@ -35,6 +38,7 @@ workflow dna_seq_pipeline {
           align_threads = align_threads,
           sort_threads = sort_threads,
           coverage_sampling = coverage_sampling,
+          gencore_quality = quality,
           max_memory_gb = max_memory_gb
     }
 
@@ -47,6 +51,7 @@ workflow dna_seq_pipeline {
                 referenceFasta = reference,
                 referenceFai = reference_fai,
                 threads = variant_calling_threads,
+                max_memory = max_memory_gb,
                 name = name
     }
 

--- a/dna-seq-pipeline/inputs/anton_all_together.json
+++ b/dna-seq-pipeline/inputs/anton_all_together.json
@@ -6,6 +6,7 @@
   "dna_seq_pipeline.name": "antonkulaga",
   "dna_seq_pipeline.sort_threads": 12,
   "dna_seq_pipeline.align_threads": 12,
+  "dna_seq_pipeline.variant_calling_threads": 12,
   "dna_seq_pipeline.coverage_sampling": 100,
   "dna_seq_pipeline.max_memory_gb": 48
 }

--- a/dna-seq-pipeline/inputs/cleanup/anton_cleanup.json
+++ b/dna-seq-pipeline/inputs/cleanup/anton_cleanup.json
@@ -1,5 +1,6 @@
 {
   "cleanup.is_paired": true,
   "cleanup.destination": "/data/gwas/anton/",
-  "cleanup.reads":  ["/data/gwas/anton/fastq/750018002018_WGZ_1.fq",  "/data/gwas/anton/fastq/750018002018_WGZ_2.fq"]
+  "cleanup.reads":  ["/data/gwas/anton/fastq/750018002018_WGZ_1.fq",  "/data/gwas/anton/fastq/750018002018_WGZ_2.fq"],
+  "cleanup.threads": 12
 }

--- a/dna-seq-pipeline/inputs/variant_calling/anton_simple_variant_calling.json
+++ b/dna-seq-pipeline/inputs/variant_calling/anton_simple_variant_calling.json
@@ -4,5 +4,7 @@
   "simple_variant_calling.bai": "/data/gwas/anton/aligned/antonkulaga.bam.bai",
   "simple_variant_calling.referenceFai": "/data/ensembl/102/species/homo_sapiens/Homo_sapiens.GRCh38.dna.primary_assembly.fa.fai",
   "simple_variant_calling.name": "antonkulaga",
-  "simple_variant_calling.destination": "/data/gwas/anton/variants"
+  "simple_variant_calling.destination": "/data/gwas/anton/variants",
+  "simple_variant_calling.threads": 16,
+  "simple_variant_calling.max_memory": 48
 }

--- a/dna-seq-pipeline/simple_variant_calling.wdl
+++ b/dna-seq-pipeline/simple_variant_calling.wdl
@@ -8,19 +8,30 @@ workflow simple_variant_calling {
         String destination
         File referenceFasta
         File referenceFai
-        Int threads = 16
-        Int max_memory = 28
+        Int threads# = 16
+        Int max_memory# = 28
         String name
     }
 
-      call smoove{
-            input:
-                bam = bam, bai = bai, reference = referenceFasta, reference_index = referenceFai, sample = name
+    call smoove{
+        input:
+            bam = bam, 
+            bai = bai, 
+            reference = referenceFasta, 
+            reference_index = referenceFai, 
+            sample = name,
+            max_memory = max_memory,
+            max_cores = threads,
         }
 
     call strelka2_germline{
         input:
-            bam = bam, bai = bai, reference_fasta = referenceFasta, reference_fai= referenceFai, cores = threads
+            bam = bam, 
+            bai = bai, 
+            reference_fasta = referenceFasta, 
+            reference_fai= referenceFai, 
+            cores = threads,
+            max_memory = max_memory,
             #,indel_candidates = manta_germline_sv.manta_indel_candidates
     }
 
@@ -57,8 +68,8 @@ task strelka2_germline{
         Boolean exome = false
         Boolean rna = false
 
-        Int cores = 8
-        Int max_memory = 28
+        Int cores# = 8
+        Int max_memory# = 28
     }
 
     command {
@@ -96,8 +107,8 @@ task smoove {
         File reference_index
         String sample
         String outputDir = "./smoove"
-        Int max_memory = 16
-        Int max_cores = 8
+        Int max_memory# = 16
+        Int max_cores# = 8
     }
 
     command {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - ./data/databases/mysql:/var/lib/mysql-files
     ports:
       - "3307:3306"
+    cap_add:
+      - SYS_NICE
   cromwell-client:
     image: quay.io/comp-bio-aging/cromwell-web:latest
     environment:

--- a/dvc.lock
+++ b/dvc.lock
@@ -58,21 +58,22 @@ prepare_vep:
     size: 1373726
     nfiles: 71
 prepare_annotations:
-  cmd: echo "prepare annotations" && cat data/gwas/annotations/gene2phenotype/DDG2P.csv  data/gwas/annotations/gene2phenotype/CancerG2P.csv  data/gwas/annotations/gene2phenotype/EyeG2P.csv  data/gwas/annotations/gene2phenotype/SkinG2P.csv  >
-    data/gwas/annotations/gene2phenotype/AllG2P.csv
+  cmd: "gunzip -c data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz\
+    \ |\n   awk '($1 ~ /^snpId/ || $2 ~ /NA/) {next} {print $0}' |\n   sort -t $'\\\
+    t' -k2,2 -k3,3n |\n   awk '{ gsub (/\\t +/, \"\\t\", $0); print}' |\n   bgzip\
+    \ -c > data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz\
+    \ &&\nrm -f data/gwas/annotations/gene2phenotype/AllG2P.csv && awk '(NR == 1)\
+    \ || (FNR > 1)' data/gwas/annotations/gene2phenotype/*.csv  > data/gwas/annotations/gene2phenotype/AllG2P.csv"
   deps:
-  - path: data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
-    md5: 05ff81dc87278116b0330df99fced244
-    size: 101101733
-  - path: data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi
-    md5: fdce855c944ba7794fc2723d46376d79
-    size: 492382
+  - path: data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz
+    md5: a393c9e8e104297aadcb7188f6460eaf
+    size: 11171100
   - path: data/gwas/annotations/clinvar.vcf.gz
-    md5: 9fab121ac6a9952ab03314f2cf3f5c3f
-    size: 34706610
+    md5: 487e6796ae4be8696d51ef450d5793de
+    size: 34713404
   - path: data/gwas/annotations/clinvar.vcf.gz.tbi
-    md5: 4c9982e21d729ca921297796d1adabf6
-    size: 293444
+    md5: b85b29f474a7f6899ddf1ad8b8c21140
+    size: 293552
   - path: data/gwas/annotations/gene2phenotype/CancerG2P.csv
     md5: 6504732dc971b2578c21a8cbd6c2d3ad
     size: 19914
@@ -86,9 +87,12 @@ prepare_annotations:
     md5: 15e1b25db13f3929357ba3dba60e7e1b
     size: 214278
   outs:
+  - path: data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
+    md5: 3d5dea024369a02f300ca3346eedc967
+    size: 9918420
   - path: data/gwas/annotations/gene2phenotype/AllG2P.csv
-    md5: 4625ef5e8af2b12c6ebff6b95598d503
-    size: 1232089
+    md5: ccf679127863b2832ccb1ceb2561502a
+    size: 1231432
 prepare_vep_plugins:
   cmd: unzip -u data/ensembl/102/102.zip -d data/ensembl/102/ && mv data/ensembl/102/VEP_plugins-release-102
     data/ensembl/102/plugins
@@ -112,3 +116,45 @@ prepare_vep_cache:
     md5: 25c0055ed80db44da92d515f2f15fcdb.dir
     size: 14518341479
     nfiles: 13883
+prepare_annotations_clinvar:
+  cmd: echo "Clinvars annotations prepared"
+  deps:
+  - path: data/gwas/annotations/clinvar.vcf.gz
+    md5: 487e6796ae4be8696d51ef450d5793de
+    size: 34713404
+  - path: data/gwas/annotations/clinvar.vcf.gz.tbi
+    md5: b85b29f474a7f6899ddf1ad8b8c21140
+    size: 293552
+prepare_annotations_gene2phenotype:
+  cmd: rm -f data/gwas/annotations/gene2phenotype/AllG2P.csv && awk '(NR == 1) ||
+    (FNR > 1)' data/gwas/annotations/gene2phenotype/*.csv  > data/gwas/annotations/gene2phenotype/AllG2P.csv
+  deps:
+  - path: data/gwas/annotations/gene2phenotype/CancerG2P.csv
+    md5: 6504732dc971b2578c21a8cbd6c2d3ad
+    size: 19914
+  - path: data/gwas/annotations/gene2phenotype/DDG2P.csv
+    md5: d21a0e446a3cc3b3adbae486cd6d11c6
+    size: 776664
+  - path: data/gwas/annotations/gene2phenotype/EyeG2P.csv
+    md5: 9bf5d96096c52df97792b165fbfeda45
+    size: 221233
+  - path: data/gwas/annotations/gene2phenotype/SkinG2P.csv
+    md5: 15e1b25db13f3929357ba3dba60e7e1b
+    size: 214278
+  outs:
+  - path: data/gwas/annotations/gene2phenotype/AllG2P.csv
+    md5: ccf679127863b2832ccb1ceb2561502a
+    size: 1231432
+prepare_annotations_digenet:
+  cmd: "gunzip -c data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz\
+    \ |\n   awk '($1 ~ /^snpId/ || $2 ~ /NA/) {next} {print $0}' |\n   sort -t $'\\\
+    t' -k2,2 -k3,3n |\n   awk '{ gsub (/\\t +/, \"\\t\", $0); print}' |\n   bgzip\
+    \ -c > data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz"
+  deps:
+  - path: data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz
+    md5: a393c9e8e104297aadcb7188f6460eaf
+    size: 11171100
+  outs:
+  - path: data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
+    md5: 3d5dea024369a02f300ca3346eedc967
+    size: 9918420

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -27,23 +27,34 @@ stages:
       mv data/ensembl/102/VEP_plugins-release-102 data/ensembl/102/plugins
     outs:
       - data/ensembl/102/plugins/
-  prepare_annotations:
+  prepare_annotations_digenet:
     deps:
+      - data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz
+    cmd: >-
+      gunzip -c data/gwas/annotations/all_variant_disease_pmid_associations.tsv.gz |
+         awk '($1 ~ /^snpId/ || $2 ~ /NA/) {next} {print $0}' |
+         sort -t $'\t' -k2,2 -k3,3n |
+         awk '{ gsub (/\t +/, "\t", $0); print}' |
+         bgzip -c > data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
+    outs:
       - data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz
-      - data/gwas/annotations/all_variant_disease_pmid_associations_final.tsv.gz.tbi
+  prepare_annotations_clinvar:
+    deps:
       - data/gwas/annotations/clinvar.vcf.gz
       - data/gwas/annotations/clinvar.vcf.gz.tbi
+    cmd: echo "Clinvars annotations prepared"       
+# https://www.ebi.ac.uk/gene2phenotype/downloads/ has no E-Tag!
+  prepare_annotations_gene2phenotype: 
+    deps:
       - data/gwas/annotations/gene2phenotype/DDG2P.csv
       - data/gwas/annotations/gene2phenotype/CancerG2P.csv
       - data/gwas/annotations/gene2phenotype/EyeG2P.csv
       - data/gwas/annotations/gene2phenotype/SkinG2P.csv
     cmd: >- 
-      echo "prepare annotations" && cat
-      data/gwas/annotations/gene2phenotype/DDG2P.csv 
-      data/gwas/annotations/gene2phenotype/CancerG2P.csv 
-      data/gwas/annotations/gene2phenotype/EyeG2P.csv 
-      data/gwas/annotations/gene2phenotype/SkinG2P.csv 
+      rm -f data/gwas/annotations/gene2phenotype/AllG2P.csv &&
+      awk '(NR == 1) || (FNR > 1)' data/gwas/annotations/gene2phenotype/*.csv 
       > data/gwas/annotations/gene2phenotype/AllG2P.csv
+#     && for f in data/gwas/annotations/gene2phenotype/*.gz ; do gunzip -c "$f" > data/gwas/annotations/gene2phenotype/"${f%.*}" ; done 
     outs:
       - data/gwas/annotations/gene2phenotype/AllG2P.csv
 

--- a/preparation/bam_to_fastq.wdl
+++ b/preparation/bam_to_fastq.wdl
@@ -4,7 +4,7 @@ workflow bam_to_fastq {
 
     input {
         File bam #750018002018_WGZ.bam
-        Int threads = 28
+        Int threads
         String destination
     }
 

--- a/preparation/inputs/anton_bam_to_fastq.json
+++ b/preparation/inputs/anton_bam_to_fastq.json
@@ -1,4 +1,5 @@
 {
   "bam_to_fastq.bam": "/data/results/anton/result_alignment/750018002018_WGZ.bam",
-  "bam_to_fastq.destination": "/data/results/anton/result_alignment/fastq"
+  "bam_to_fastq.destination": "/data/results/anton/result_alignment/fastq",
+  "bam_to_fastq.threads": "28"
 }


### PR DESCRIPTION
to all wdls:
- threading and mem moved to jsons. 
to vep:
- db-host support (main mirror is down atm), 
tbi processing, 
- vcf and vcf.gz input support; 
- docker host-network for cromwell (ugly hack) to fix perl DBI connection to mysql
to comose:
- fixed mbind permissions spam
to dvc:
- disease_pmid_associations are now downloaded from site and tbi is produced in vep pipeline
